### PR TITLE
Set collections support

### DIFF
--- a/src/main/scala/org/msgpack/template/GenericImmutableSetTemplate.scala
+++ b/src/main/scala/org/msgpack/template/GenericImmutableSetTemplate.scala
@@ -1,0 +1,27 @@
+//
+//  MessagePack for Scala
+//
+//  Copyright (C) 2009-2011 FURUHASHI Sadayuki
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+
+package org.msgpack.template
+
+class GenericImmutableSetTemplate extends GenericTemplate {
+
+  def build(params: Array[Template[_]]) = {
+    new ImmutableSetTemplate[Any](params(0).asInstanceOf[Template[Any]])
+  }
+  
+}

--- a/src/main/scala/org/msgpack/template/GenericMutableSetTemplate.scala
+++ b/src/main/scala/org/msgpack/template/GenericMutableSetTemplate.scala
@@ -1,0 +1,37 @@
+//
+//  MessagePack for Scala
+//
+//  Copyright (C) 2009-2011 FURUHASHI Sadayuki
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+
+package org.msgpack.template
+
+/**
+ * 
+ * User: Tsuyoshi Ozawa
+ * Create: 13/13/1 12:43
+ */
+
+class GenericMutableSetTemplate[T <: MutableSetTemplate[_,_]](implicit manifest : Manifest[T]) extends GenericTemplate {
+
+  val constructor = {
+    val c = manifest.erasure
+    c.getConstructor(classOf[Template[_]])
+  }
+
+  def build(params: Array[Template[_]]) = {
+    constructor.newInstance(params(0)).asInstanceOf[T]
+  }
+}

--- a/src/main/scala/org/msgpack/template/ImmutableSetTemplate.scala
+++ b/src/main/scala/org/msgpack/template/ImmutableSetTemplate.scala
@@ -1,0 +1,54 @@
+//
+// MessagePack for Scala
+//
+// Copyright (C) 2009-2013 FURUHASHI Sadayuki
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.template
+
+import org.msgpack._
+import packer.Packer
+import unpacker.Unpacker
+
+class ImmutableSetTemplate[T](elementTemplate : Template[T]) extends AbstractTemplate[Set[T]]{
+
+
+  def read(u: Unpacker, to: Set[T], required: Boolean) : Set[T] = {
+    if(!required && u.trySkipNil){
+      return null.asInstanceOf[Set[T]]
+    }
+    val length = u.readArrayBegin()
+    val set = for(i <- 0 until length) yield  elementTemplate.read(u,null.asInstanceOf[T],required)
+    u.readArrayEnd
+
+    set.toSet
+  }
+
+  def write(packer: Packer, v: Set[T], required: Boolean) : Unit = {
+    if(v == null){
+      if(required){
+        throw new MessageTypeException("Attempted to write null")
+      }
+      packer.writeNil()
+      return
+    }
+
+    packer.writeArrayBegin(v.size)
+    v.foreach(e => {
+      elementTemplate.write(packer,e,required)
+    })
+    packer.writeArrayEnd()
+
+  }
+}

--- a/src/main/scala/org/msgpack/template/MutableSetTemplate.scala
+++ b/src/main/scala/org/msgpack/template/MutableSetTemplate.scala
@@ -1,0 +1,90 @@
+//
+// MessagePack for Scala
+//
+// Copyright (C) 2009-2013 FURUHASHI Sadayuki
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.template
+
+import org.msgpack.packer.Packer
+import org.msgpack.unpacker.Unpacker
+import org.msgpack.MessageTypeException
+import scala.collection.mutable.LinkedHashSet
+import scala.collection.mutable.HashSet
+import scala.collection.mutable.BitSet
+import scala.collection.mutable.Set
+;
+
+/*
+ * Author: Tsuyoshi Ozawa
+ */
+
+abstract class MutableSetTemplate[V,T <: Set[V]](elementTemplate : Template[V])  extends AbstractTemplate[T]{
+
+
+  def read(packer: Unpacker, to: T, required: Boolean) : T = {
+    if(!required && packer.trySkipNil){
+      return null.asInstanceOf[T]
+    }
+
+    var set : T = if(to == null){
+      createNewSet()
+    }else{
+      to
+    }
+    val length = packer.readArrayBegin
+    for(i <- 0 until length){
+      set = (set + elementTemplate.read(packer,null.asInstanceOf[V])).asInstanceOf[T]
+    }
+    packer.readArrayEnd
+    set
+  }
+
+  def write(packer: Packer, v: T, required: Boolean) : Unit = {
+    if(v == null){
+      if(required){
+        throw new MessageTypeException("Attempted to write null")
+      }
+      packer.writeNil
+      return
+    }
+    packer.writeArrayBegin(v.size)
+    v.foreach(e => elementTemplate.write(packer,e))
+    packer.writeArrayEnd()
+  }
+
+  def createNewSet() : T
+
+}
+
+// 2.10 or later.
+//class SortedSetTemplate[V](elementTemplate : Template[V])
+//  extends MutableSetTemplate[V,SortedSet[V]](elementTemplate){
+//  def createNewSet() = SortedSet.empty
+//}
+
+class MutableSetCTemplate[V](elementTemplate : Template[V])
+  extends MutableSetTemplate[V,Set[V]](elementTemplate){
+  def createNewSet() = Set.empty
+}
+
+class LinkedHashSetTemplate[V](elementTemplate : Template[V])
+  extends MutableSetTemplate[V,LinkedHashSet[V]](elementTemplate){
+  def createNewSet() = LinkedHashSet.empty
+}
+
+class HashSetTemplate[V](elementTemplate : Template[V])
+  extends MutableSetTemplate[V,HashSet[V]](elementTemplate){
+  def createNewSet() = HashSet.empty
+}

--- a/src/main/scala/org/msgpack/template/ScalaTemplateRegistry.scala
+++ b/src/main/scala/org/msgpack/template/ScalaTemplateRegistry.scala
@@ -43,11 +43,15 @@ class ScalaTemplateRegistry extends TemplateRegistry(null){
     val at = new AnyTemplate[Any](this)
     def anyTemplate[T] = at.asInstanceOf[Template[T]]
     register(new ImmutableListTemplate[Any](anyTemplate))
+    register(new ImmutableSetTemplate[Any](anyTemplate))
     register(new ImmutableMapTemplate(anyTemplate,anyTemplate))
     register(new DoubleLinkedListTemplate(anyTemplate))
     register(new LinkedListTemplate(anyTemplate))
     register(new ListBufferTemplate(anyTemplate))
     register(new MutableListCTemplate(anyTemplate))
+    register(new MutableSetCTemplate(anyTemplate))
+    register(new HashSetTemplate(anyTemplate))
+    register(new LinkedHashSetTemplate(anyTemplate))
     register(new MutableHashMapTemplate(anyTemplate,anyTemplate))
     register(new MutableListMapTemplate(anyTemplate,anyTemplate))
     register(new MutableLinkedHashMapTemplate(anyTemplate,anyTemplate))
@@ -55,7 +59,12 @@ class ScalaTemplateRegistry extends TemplateRegistry(null){
     new MutableHashMapTemplate(anyTemplate,anyTemplate))
     register(classOf[scala.collection.mutable.Seq[_]],
       new LinkedListTemplate(anyTemplate))
+    register(classOf[scala.collection.mutable.Set[_]],
+      new LinkedHashSetTemplate(anyTemplate))
+    register(classOf[scala.collection.mutable.Set[_]],
+      new HashSetTemplate(anyTemplate))
     register(classOf[Seq[_]],new ImmutableListTemplate(anyTemplate))
+    register(classOf[Set[_]],new ImmutableSetTemplate(anyTemplate))
     register(classOf[scala.collection.immutable.List[_]],new ImmutableListTemplate[Any](anyTemplate))
     register(classOf[java.util.Calendar],new CalendarTemplate)
     register(None.getClass,new OptionTemplate[Any](anyTemplate))
@@ -91,6 +100,7 @@ class ScalaTemplateRegistry extends TemplateRegistry(null){
     registerGeneric(classOf[scala.collection.immutable.List[_]],new GenericImmutableListTemplate())
     registerGeneric(classOf[scala.collection.immutable.Map[_,_]],new GenericImmutableMapTemplate())
     registerGeneric(classOf[scala.collection.immutable.Seq[_]],new GenericImmutableListTemplate())
+    registerGeneric(classOf[scala.collection.immutable.Set[_]],new GenericImmutableSetTemplate())
     registerGeneric(classOf[scala.collection.Seq[_]],new GenericImmutableListTemplate())
     registerGeneric(classOf[Seq[_]],new GenericImmutableListTemplate())
 
@@ -104,6 +114,12 @@ class ScalaTemplateRegistry extends TemplateRegistry(null){
       new GenericMutableListTemplate[LinkedListTemplate[_]]())
     registerGeneric(classOf[scala.collection.mutable.Seq[_]],
       new GenericMutableListTemplate[LinkedListTemplate[_]]())
+    registerGeneric(classOf[scala.collection.mutable.Set[_]],
+      new GenericMutableSetTemplate[MutableSetCTemplate[_]]())
+    registerGeneric(classOf[HashSet[_]],
+      new GenericMutableSetTemplate[HashSetTemplate[_]]())
+    registerGeneric(classOf[LinkedHashSet[_]],
+      new GenericMutableSetTemplate[LinkedHashSetTemplate[_]]())
 
     registerGeneric(classOf[LinkedHashMap[_,_]],
       new GenericMutableMapTemplate[MutableLinkedHashMapTemplate[_,_]])

--- a/src/test/scala/org/msgpack/ClassWithSet.scala
+++ b/src/test/scala/org/msgpack/ClassWithSet.scala
@@ -1,0 +1,40 @@
+//
+// MessagePack for Scala
+//
+// Copyright (C) 2009-2013 FURUHASHI Sadayuki
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack;
+
+import annotation.{Message, MessagePackMessage}
+import collection.mutable.{Set => MutableSet, LinkedHashSet, HashSet}
+import collection.immutable.{Set => ImmutableSet}
+
+
+@MessagePackMessage
+class ClassWithSet {
+  var immutable : ImmutableSet[String] = ImmutableSet.empty;
+  var mutable1 : MutableSet[String] = MutableSet.empty
+  var mutable2 : LinkedHashSet[String] = LinkedHashSet.empty
+  var mutable3 : HashSet[String] = HashSet.empty
+}
+
+@MessagePackMessage
+class ClassWithPrimitiveTypeSet {
+  var intSet : ImmutableSet[Int] = ImmutableSet.empty
+  var longSet : ImmutableSet[Long] = ImmutableSet.empty
+  var boolSet : ImmutableSet[Boolean] = ImmutableSet.empty
+  var doubleSet : ImmutableSet[Double] = ImmutableSet.empty
+  var floatSet : ImmutableSet[Float] = ImmutableSet.empty
+}

--- a/src/test/scala/org/msgpack/CollectionPackSpec.scala
+++ b/src/test/scala/org/msgpack/CollectionPackSpec.scala
@@ -18,6 +18,7 @@
 package org.msgpack
 
 import scala.collection.mutable.{ListBuffer, LinkedList}
+import scala.collection.mutable.{Set => MutableSet, LinkedHashSet, HashSet}
 import org.specs2.mutable.SpecificationWithJUnit
 
 //import org.scalacheck.Gen
@@ -74,6 +75,34 @@ class CollectionPackTest extends SpecificationWithJUnit  {
 
 
     }
+    "pack scala-set" in {
+      val c = new ClassWithSet
+
+      c.immutable = Set("z") ++ Set("a","b","c")
+      c.mutable1 = MutableSet("a","b","d")
+      c.mutable2 ++= LinkedHashSet("gh","fjei")
+      c.mutable3 = HashSet("fdk","fei")
+
+      val b = ScalaMessagePack.write(c)
+      val des = ScalaMessagePack.read[ClassWithSet](b)
+
+      des must hasEqualProps(c).on("immutable","mutable1","mutable2","mutable3")
+    }
+    "pack scala-primitive-type-set" in {
+      val c = new ClassWithPrimitiveTypeSet
+
+      c.intSet = Set(1,5,2)
+      c.longSet = Set(80L,23L,19381298L)
+      c.boolSet = Set(false,true)
+      c.floatSet = Set(2.0f,32f)
+      c.doubleSet = Set(1.0,482.92)
+
+      val b = ScalaMessagePack.write(c)
+      val des = ScalaMessagePack.read[ClassWithPrimitiveTypeSet](b)
+
+      des must hasEqualProps(c).on("intSet","longSet","boolSet","floatSet","doubleSet")
+    }
+    
     "pack scala-map" in {
       val c = new ClassWithMap
       c.immutable = Map("a" -> "hoge","b" -> "fuga","c" -> "hehe")


### PR DESCRIPTION
One current missing feature in msgpack for Scala is to support mutable/immutable Set collections. This commits support the feature.

Signed-off-by: Tsuyoshi Ozawa ozawa.tsuyoshi@gmail.com
