### PR TITLE
fix RichValue#as

### DIFF
--- a/src/main/scala/org/msgpack/conversion/RichValue.scala
+++ b/src/main/scala/org/msgpack/conversion/RichValue.scala
@@ -18,6 +18,7 @@
 
 package org.msgpack.conversion
 
+import org.msgpack.scalautil.MyParameterizedType
 import org.msgpack.MessagePack
 import org.msgpack.`type`.{ValueFactory, Value}
 
@@ -60,7 +61,8 @@ class RichValue(messagePack : MessagePack,value : Value){
   }
 
   def as[T](implicit manifest : Manifest[T]) : T = {
-    messagePack.convert(value,manifest.erasure.asInstanceOf[Class[T]])
+    val t = messagePack.lookup(MyParameterizedType(manifest))
+    messagePack.convert(value, t).asInstanceOf[T]
   }
 
   def asMap[K,V](implicit keyManife : Manifest[K] , valueManife : Manifest[V]) : Map[K,V] = {

--- a/src/test/scala/org/msgpack/ImplicitConversionTest.scala
+++ b/src/test/scala/org/msgpack/ImplicitConversionTest.scala
@@ -133,6 +133,16 @@ class ImplicitConversionTest extends SpecificationWithJUnit{
     }
 
 
+    "convert value to tuple using RichValue#as" in{
+      import ScalaMessagePack._
+
+      val t = (1,"foo")
+      val data = writeV(t)
+      val decoded = readAsValue(data)
+      val richValue : RichValue = decoded
+      val r = richValue.as[(Int,String)]
+      r must_== t
+    }
   }
 
 


### PR DESCRIPTION
to enable parametrized type to be converted from value using RichValue#as

e.g. `readAsValue(writeV((1,2))).as[(Int,Int)]` doesn't work now. 

NOTE: This commit requires the commit of msgpack-java (choplin/msgpack-java@50d77092c045298267ffb822b338a469aa3ea70e).
A pull request for this commit has already been opend, but not merged yet.
