### PR TITLE
Bump msgpack-java to 0.6.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An implementation of [MessagePack](http://msgpack.org/) for Scala.
 
 Add dependency.
 
-    libraryDependencies += "org.msgpack" %% "msgpack-scala" % "0.6.11"
+    libraryDependencies += "org.msgpack" %% "msgpack-scala" % "0.6.12"
 
 
 ## For developer

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ import xerial.sbt.Sonatype.sonatypeSettings
 
 object MessagePackScalaBuild extends Build {
   
-  val messagePackVersion = "0.6.11"
+  val messagePackVersion = "0.6.12"
 
   private[this] final val scala211 = "2.11.6"
 


### PR DESCRIPTION
msgpack-java 0.6.11 is broken due to https://github.com/msgpack/msgpack-java/issues/213
